### PR TITLE
A more clear indication that an argument is an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ not a fully baked proposal.
 Here’s how the API for setting IsLoggedIn to true could look:
 
 ```
-navigator.setLoggedIn(
+navigator.setLoggedIn({
     username: non-whitespace string of limited length,
     credentialTokenType: “httpStateToken” OR “legacyAuthCookie”,
     optionalParams { }
-) –> Promise<void>
+}) –> Promise<void>
 ```
 
 The returned promise would resolve if the status was set and reject if


### PR DESCRIPTION
Hi.
At the moment, it's not entirely clear if `navigator.setLoggedIn` accepts an object as an argument, or it is a comma-separated list of arguments.
If I am correct and it is an object — it would make it more clear.