### PR TITLE
A proposal for framing the Login Status API that reconciles how FedCM/SAA are planning to use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Below we present a proposal for how a web API for logged in status could look an
 
 ### Representation and Storage
 
-The website's **self-declared** login status is represented as a single bit (or lack of one) **per origin** with the following possible values:
+The website's **self-declared** login status is represented as a three-state value **per origin** with the following possible values:
 
 - `unknown`: the browser has never observed a login nor a logout
 - `logged-in`: a user has logged-in to **an** account on the website
@@ -135,7 +135,7 @@ Every user of the login status (e.g. Web Standards or browser features integrati
 
 One potential for abuse is if websites don’t call the logout API when they should. This could allow them to maintain the privileges tied to login status even after the user logged out.
 
-Features using the Login Status bit need to assume that (1) an (2) are the case and design their security and privacy models under these conditions.
+Features using the Login Status need to assume that (1) an (2) are the case and design their security and privacy models under these conditions.
 
 ## Challenges and Open Questions
 

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ of the [Privacy Community Group](https://privacycg.github.io/).
 
 ## Introduction
 
-This explainer proposes a Web Platform API called the Login Status API which websites can use to inform the browser of their users's login status, so that other Web APIs can operate with this additional signal.
+This explainer proposes a Web Platform API called the **Login Status API** which websites can use to inform the browser of their users's login status, so that other Web APIs can operate with this additional signal.
 
 On one side, browsers don't have any built-in notion of whether the user is logged in or not.  Neither the existence  of cookies nor frequent/recent user interaction can serve that purpose since  most users have cookies for and interact with plenty of websites they are not logged-in to. High level Web Platform APIs, such as form submission with username/password fields,  WebAuthn, WebOTP and FedCM, can (implicitly) record login, but don't record logout - so the browser doesn't know if the user is logged in or not.
 
 On the other side, there is an increasing number of Web Platform APIs (e.g. [FedCM](https://github.com/privacycg/is-logged-in/issues/53), [Storage Access API](https://github.com/privacycg/storage-access/issues/8)) and Browser features (e.g. visual cues in the url bar, freeing up long term disk and backup space) that could perform better under the assumption of whether the user is logged in or not.
 
-This proposal aims at creating a set of APIs (e.g. HTTP headers, JS APIs and Cookie annotations) to manage a deliberate, explicit, opted-in and self-declared signal that websites can use to inform the browser.
+This proposal aims at creating a set of **extensible** APIs (e.g. HTTP headers, JS APIs and Cookie annotations) to manage a deliberate, explicit, **opted-in** and **self-declared** signal that websites can use to inform the browser.
 
-Because of the self-declared property of the signal, Web Platform APIs and Browser features have to design their use with abuse in mind.
+Because of the self-declared property of the signal, Web Platform APIs and Browser features **must** design their use with **abuse** in mind.
 
 ## Proposal
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ of the [Privacy Community Group](https://privacycg.github.io/).
 
 This explainer proposes a Web Platform API called the **Login Status API** which websites can use to inform the browser of their users's login status, so that other Web APIs can operate with this additional signal.
 
-On one side, browsers don't have any built-in notion of whether the user is logged in or not.  Neither the existence  of cookies nor frequent/recent user interaction can serve that purpose since  most users have cookies for and interact with plenty of websites they are not logged-in to. High level Web Platform APIs, such as form submission with username/password fields,  WebAuthn, WebOTP and FedCM, can (implicitly) record login, but don't record logout - so the browser doesn't know if the user is logged in or not.
+On one hand, browsers don't have any built-in notion of whether the user is logged in or not.  Neither the existence  of cookies nor frequent/recent user interaction can serve that purpose since  most users have cookies for and interact with plenty of websites they are not logged-in to. High level Web Platform APIs, such as form submission with username/password fields,  WebAuthn, WebOTP and FedCM, can (implicitly) record login, but don't record logout - so the browser doesn't know if the user is logged in or not.
 
-On the other side, there is an increasing number of Web Platform APIs (e.g. [FedCM](https://github.com/privacycg/is-logged-in/issues/53), [Storage Access API](https://github.com/privacycg/storage-access/issues/8)) and Browser features (e.g. visual cues in the url bar, freeing up long term disk and backup space) that could perform better under the assumption of whether the user is logged in or not.
+On the other hand, there is an increasing number of Web Platform APIs (e.g. [FedCM](https://github.com/privacycg/is-logged-in/issues/53), [Storage Access API](https://github.com/privacycg/storage-access/issues/8)) and Browser features (e.g. visual cues in the url bar, freeing up long term disk and backup space) that could perform better under the assumption of whether the user is logged in or not.
 
-This proposal aims at creating a set of **extensible** APIs (e.g. HTTP headers, JS APIs and Cookie annotations) to manage a deliberate, explicit, **opted-in** and **self-declared** signal that websites can use to inform the browser.
+This proposal aims at creating a set of **extensible** APIs (e.g. HTTP headers, JS APIs, and Cookie annotations) to manage a deliberate, explicit, **opted-in** and **self-declared** signal that websites can use to inform the browser.
 
 Because of the self-declared property of the signal, Web Platform APIs and Browser features **must** design their use with **abuse** in mind.
 
@@ -44,11 +44,11 @@ The website's **self-declared** login status is represented as a single bit **pe
 
  By **default**, every origin has their login status bit set to `unknown`.
 
-The login status bit represents the **client-side** state of the origin in the browser and can be out-of-date with the **server-side** state (e.g. a user can delete their account in another browser instance).
+The login status bit represents the **client-side** state of the origin in the browser and can be out-of-date with the **server-side** state (e.g. a user can delete their account in another browser instance). Even then, due to cookie expiration, it is an imperfect representation of the client-side state, in that it may be outdated.
 
 ### Setting the Login Status
 
-There are many mechanisms that a website can use to set the login status:
+There are several mechanisms that a website can use to set the login status:
 
 > TODO: figure out if we can put these behind user activation.
 
@@ -60,7 +60,6 @@ Here’s how the API for recording a login / logout could look:
 partial interface Navigator {
   Promise<void> setLoggedIn(optional LoginStatusOptions options);
   Promise<void> setLoggedOut(optional LogoutStatusOptions options);
-  Promise<bool> isLoggedIn();
 };
 
 interface LoginStatusOptions {

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Explainer: Login Status API
 
 A [Work Item](https://privacycg.github.io/charter.html#work-items)
@@ -5,10 +6,12 @@ of the [Privacy Community Group](https://privacycg.github.io/).
 
 ## Editors:
 
-- [John Wilander](https://github.com/johnwilander), Apple Inc.
+- (suggestion) [John Wilander](https://github.com/johnwilander), Apple Inc.
+- (suggestion) [Ben Vandersloot](https://github.com/bvandersloot), Mozilla
+- (suggestion) [Sam Goto](https://github.com/samuelgoto), Google Inc.
 
 ## Participate
-- https://github.com/privacycg/is-logged-in/issues
+- https://github.com/privacycg/login-status-api/issues
 
 ## Table of Contents
 
@@ -17,240 +20,155 @@ of the [Privacy Community Group](https://privacycg.github.io/).
 
 ## Introduction
 
-This explainer proposes an API called the Login Status API with which
-websites can inform the web browser of the user's login status.
+This explainer proposes a Web Platform API called the Login Status API which websites can use to inform the browser of their users's login status, so that other Web APIs can operate with this additional signal.
 
-Currently, web browsers have no way of knowing if the user is logged in
-to a particular website. Neither the existence of cookies nor
-frequent/recent user interaction can serve that purpose since most users
-have cookies for and interact with plenty of websites they are not
-logged in to.
+On one side, browsers don't have any built-in notion of whether the user is logged in or not.  Neither the existence  of cookies nor frequent/recent user interaction can serve that purpose since  most users have cookies for and interact with plenty of websites they are not logged-in to. High level Web Platform APIs, such as form submission with username/password fields,  WebAuthn, WebOTP and FedCM, can (implicitly) record login, but don't record logout - so the browser doesn't know if the user is logged in or not.
 
-### Why Do Browsers Need To Know?
+On the other side, there is an increasing number of Web Platform APIs (e.g. [FedCM](https://github.com/privacycg/is-logged-in/issues/53), [Storage Access API](https://github.com/privacycg/storage-access/issues/8)) and Browser features (e.g. visual cues in the url bar, freeing up long term disk and backup space) that could perform better under the assumption of whether the user is logged in or not.
 
-The current behavior of the web is “logged in by default,” meaning as
-soon as the browser loads a webpage, that page can store data such as
-cookies virtually forever on the device. That is a serious privacy issue
-and also bad for disk and backup space. Long term storage should instead
-be tied to where the user is truly logged in.
+This proposal aims at creating a set of APIs (e.g. HTTP headers, JS APIs and Cookie annotations) to manage a deliberate, explicit, opted-in and self-declared signal that websites can use to inform the browser.
 
-There could be other powerful features and relaxations of restrictions
-besides storage that the web browser only wants to offer to websites
-where the user is logged in.
+Because of the self-declared property of the signal, Web Platform APIs and Browser features have to design their use with abuse in mind.
 
-The ability to do these things requires knowledge of where the user is
-logged in.
+## Proposal
 
-## Existing Functionality
+Below we present a proposal for how a web API for logged in status could look and work. This is a starting point for a conversation, not a fully baked proposal.
 
-In olden times, Basic/Digest Authentication offered a way for browsers
-to know where the user was logged in and help them to stay logged in.
-However, there was never a way to log out. Regardless, those
-technologies are now obsolete for many reasons. Today,
-[WebAuthn](https://w3c.github.io/webauthn/) and password managers
-(including the use of [Credential
-Management](https://w3c.github.io/webappsec-credential-management/))
-offer a browser-managed way to log in but those features neither cover
-the expiry of the logged in session nor the act of logging out.
+### Representation and Storage
 
-Cookies and other kinds of storage may carry login state but there is no
-way to tell general storage and authentication tokens apart. Persistent
-cookies have an expiry function which could serve as an automatic
-inactivity logout mechanism whereas web storage such as IndexedDB
-doesn’t even have an expiry functionality.
+The website's **self-declared** login status is represented as a single bit **per origin** with the following possible values:
 
-## Straw Man Proposal
+- `unknown`: the browser has never observed a login nor a logout
+- `logged-in`: a user has logged-in to **an** account on the website
+- `logged-out`: the user has logged-out of **all** accounts on the website
 
-Below we present a straw man proposal for how a web API for logged in
-status could look and work. This is a starting point for a conversation,
-not a fully baked proposal.
+ By **default**, every origin has their login status bit set to `unknown`.
 
-### API
+The login status bit represents the **client-side** state of the origin in the browser and can be out-of-date with the **server-side** state (e.g. a user can delete their account in another browser instance).
 
-Here’s how the API for recording a login could look:
+### Setting the Login Status
 
-```
-navigator.recordLogin(
-    username: non-whitespace string of limited length,
-    credentialTokenType: “cookie”,
-    optionalParams { }
-) –> Promise<void>
+There are many mechanisms that a website can use to set the login status:
+
+> TODO: figure out if we can put these behind user activation.
+
+#### JS API
+
+Here’s how the API for recording a login / logout could look:
+
+```javascript
+partial interface Navigator {
+  Promise<void> setLoggedIn(optional LoginStatusOptions options);
+  Promise<void> setLoggedOut(optional LogoutStatusOptions options);
+  Promise<bool> isLoggedIn();
+};
+
+interface LoginStatusOptions {
+  // To be extended by specific web platform features
+}
+
+interface LogoutStatusOptions {
+  // To be extended by specific web platform features
+}
 ```
 
-The returned promise would resolve if the status was set and reject if
-not. The API could potentially take an expiry parameter but here we’re
-assuming that a designated cookie manages the expiry of the login.
+#### HTTP API
 
-Here’s how the API for recording a logout could look:
+Here is how a HTTP server could operate on the signals:
 
-```
-navigator.recordLogout(optionalUsername) –> Promise<void>
-```
-
-The optional username parameter highlights that we might want to support
-concurrent logins on the same website which would require the site to
-keep track of who to log out and credential tokens to be scoped to user
-names.
-
-Here’s how the API for checking the login status could look:
-
-```
-navigator.checkLoginState() –> Promise<bool>
+```javascript
+Sign-in-Status: type=idp, action=signin
+Sign-in-Status: type=idp, action=signout-all
 ```
 
-This last API could potentially be allowed to be called by third-party
-iframes that do not currently have access to their cookies and website
-data. The iframes may want to render differently depending on whether
-the user is one of their logged in customers or not.
+#### Cookie API
 
-### Defending Against Abuse
+> It is possible that we may want to annotate cookies (or [HTTP State
+Tokens](https://mikewest.github.io/http-state-tokens/draft-west-http-state-tokens.html)) so that they can convey the signal. We don't know what that looks like or whether it is needed at all, but it seemed important to acknowledge that Cookies may be an important part of API design.
 
-If websites were allowed to set login status whenever they want, it
-would not constitute a trustworthy signal and would most likely be 
-abused for user tracking. We must therefore make sure that login status
-can only be set when the browser is convinced that the user meant to log
-in or the user is already logged in and wants to stay logged in.
+### Using the Login Status
 
-Another potential for abuse is if websites don’t call the logout API
-when they should. This could allow them to maintain the privileges tied
-to login status even after the user logged out.
+The login status is a bit that is available to Web Platform APIs and Browser features outside of this specification. Specifications can extend the API to gather more specific signals needed.
 
-There are several ways the browser could make sure the login status
-is trustworthy:
+#### Examples
 
-* Require websites to use WebAuthn or a password manager (including
-  Credential Management) before calling the API.
-* Require websites to take the user through a login flow according to
-  rules that the browser can check. This would be the escape hatch for
-  websites who can’t or don’t want to use WebAuthn or a password manager
-  but still want to set login status.
-* Show browser UI acquiring user intent when login status is set.
-  Example: A prompt.
-* Continuously show browser UI indicating an active login session on
-  the particular website. Example: Some kind of indicator in the URL
-  bar.
-* Delayed browser UI acquiring user intent to stay logged in, shown some
-  time after the login status was set. Example: Seven days after login
-  status was set – “Do you want to stay logged in to news.example?”
-* Requiring engagement to maintain login status. Example: Require user
-  interaction as first party website at least every N days to stay 
-  logged in. The browser can hide instead of delete the credential token
-  past this kind of expiry to allow for quick resurrection of the login
-  session.
+##### FedCM
 
-### Credential Tokens
+[FedCM](https://github.com/privacycg/is-logged-in/issues/53#issue-1664953653) needs a mechanism that allows Identity Providers to signal to the browser when the user is logged in. It extends the Login Status API to give them that API surface.
 
-Ideally, a new Logon Status API like this would only work with modern
-login credentials. The proposed 
-[HTTP State
-Tokens](https://mikewest.github.io/http-state-tokens/draft-west-http-state-tokens.html)
-could become such a modern piece. However, to ensure a smooth path for
-adoption, we should support cookies.
-
-Both HTTP State Tokens and cookies would have to be explicitly set up
-for authentication purposes to work with the Login Status API. In the
-case of both of these token types, we could introduce an __auth- prefix
-as a signal that both the server and client consider the user to be
-logged in. Or we could allow HTTP State Token request and response
-headers to convey login status. Note that sending metadata in requests
-differs from how cookies work.
-
-The expiry of the cookie or token should be picked up as recordLogout().
-
-Cookies have the capability to span a full registrable domain and thus
-log the user in to all subdomains at once. HTTP State Tokens have a
-proper connection to origins but can be declared to span the full
-registrable domain too. We should probably let the credential token
-control the scope of the login status.
-
-Explicitly logging out should clear all website data for the website,
-not just the credential token. The reverse, the user clearing the
-credential token (individually or as part of a larger clearing of
-website data), should also log them out for the purposes of the Login
-Status API.
-
-### Federated Logins
-
-Some websites allow the user to use an existing account with a federated
-login provider to bootstrap a new local user account and subsequently
-log in. The Login Status API needs to support such logins.
-
-This could be achieved through integration between the Login Status API
-and the proposed [WebID](https://github.com/WICG/WebID).
-
-If federated logins were to be supported by the Login Status API alone,
-it could look like this:
-
-First, the federated login provider needs to call the API on its side,
-possibly after the user has clicked a “Log in with X” button:
-
-```
-navigator.initiateRecordFederatedLogin(destination: secure origin) –> Promise<void>
+```javascript
+// Records that the user is logging-in to a FedCM-compliant Identity Provider.
+navigator.setLoggedIn({
+  idp: true
+});
 ```
 
-For the promise to resolve, the user needs to already have login
-status set for the federated login provider, i.e. the user needs to
-be logged in to the provider first.
+##### Storage Access API
 
-Then the destination website has to call the API on its side:
+The [Storage Access API](https://github.com/privacycg/storage-access/issues/8#issue-560633211) needs a mechanism that allows websites to signal to the browser when the user is logged in. It may use the raw signal or extend it in case it needs more information:
 
-```
-navigator.recordFederatedLogin(
-    loginProvider: secure origin,
-    username,
-    credentialTokenType,
-    optionalParams { }
-) –> Promise<void>
+```javascript
+// Records that the user is logging-in, which allows the Storage Access API to conditionally dismiss its
+// UX.
+navigator.setLoggedIn();
 ```
 
-The promise would only resolve if the `loginProvider` had recently
-called `initiateRecordFederatedLogin()` for this destination website.
+##### Browser Status UI
+
+Much like favicons, websites may be benefited from having a login status indicator in browser UI (e.g. the URL bar). The indicator could extend the login status API to gather the explicit signals that it needs from the website to display the indicator (e.g. a name and an avatar).
+
+```javascript
+// Records that the user is logging-in to a FedCM-compliant Identity Provider.
+navigator.setLoggedIn({
+  profile: {
+    name: "John Doe",
+    picture: "https://website.com/john-doe/profile.png",
+  }
+});
+```
+
+#### The Assumption of Abuse
+
+Every user of the login-status bit **MUST** assume that the login-status bit is:
+
+1. Self-declared: any website can and will lie to gain any advantage
+2. Client-side: the state represent the website's client-side knowledge of the user's login status, which is just an approximation of the server-side's state (which is the ultimate source of truth) 
+
+One potential for abuse is if websites don’t call the logout API when they should. This could allow them to maintain the privileges tied to login status even after the user logged out.
+
+Features using the Login Status bit need to assume that (1) an (2) are the case and design their security and privacy models under these conditions.
 
 ## Challenges and Open Questions
 
-* __Grandfathering__. Some websites may not want to prompt an already
-  logged in user or take them through an additional login flow just to
-  set login status.
-* __Expiry limit__. What is a reasonable limit for expiry without
-  revisit/re-engagement?
-* __Single sign-on__. If the browser supports
-  [First Party Sets](https://github.com/privacycg/first-party-sets), it
-  may support single sign-on within the first party set, for instance
-  with an optional parameter includeFirstPartySet: [secure origin 1,
-  secure origin 2]`. The browser would check the integrity of the first
-  party set claim and potentially ask the user for their intent to log
-  in to multiple websites at once before setting login status for all
-  of them. The expiry of the login status for the first party set would
-  likely be controlled by the expiry of the credential token for the
-  single sign-on origin. However, there is not browser agreement
-  on how to support First Party Sets in a privacy preserving way.
-
 ## Considered alternatives
 
-[This should include as many alternatives as you can, from high level
-architectural decisions down to alternative naming choices.]
+### An API-specific Signal
 
-### [Alternative 1]
+One obvious alternative that occurred to us was to build a signal that is specific to each API that is being designed. Specifically, [should FedCM use its own signal or reuse the Login Status API](https://github.com/privacycg/is-logged-in/issues/53)?
 
-[Describe an alternative which was considered, and why you decided
-against it.]
+While not something that is entirely ruled out, it seemed to most of us that it would be worth trying to build a reusable signal across Web Platform features.
 
-### [Alternative 2]
+### Implicit Signals
 
-[etc.]
+Another trivial alternative is for Web Platform APIs to implicitly assume the user's login status based on other Web Platform APIs, namely username/password form submissions, WebAuthn, WebOTP and FedCM.
+
+While that's an interesting and attractive venue of exploration, it seemed like it lacked a few key properties:
+
+- first, logout isn't recorded by those APIs, so not very reliable
+- second, the login isn't explicitly done and the consequences to other Web Platform APIs isn't opted-into. 
+- third, username/passwords form submissions aren't a very reliable signal, because there are many ways in which a browser may be confused by the form submission (e.g. the password field isn't marked explicitly so but rather implemented in userland)
+
+So, while this is also not an option that is entirely ruled out, a more explicit signal from developers seemed more appropriate.
+
+### User Signal
+
+Another alternative that we considered is an explicit user signal, likely in the form of a permission prompt. While that would address most of the abuse vectors, we believed that it would be too cumbersome and hard to explain to users (specially because the benefits are in the future).
 
 ## Stakeholder Feedback / Opposition
 
-[Implementors and other stakeholders may already have publicly stated
-positions on this work. If you can, list them here with links to
-evidence as appropriate.]
+There is an overall directional intuition that something like this is a useful/reasonable addition to the Web Platform by the original proposers of this API and the APIs interested in consuming this signal (most immediately [FedCM and SAA](https://github.com/privacycg/is-logged-in/issues/53)).
 
-- [Implementor A] : Positive
-- [Stakeholder B] : No signals
-- [Implementor C] : Negative
-
-[If appropriate, explain the reasons given by other implementors for
-their concerns.]
+This is currently in an extremely early draft that is intended to gather convergence within browser vendors.
 
 ## References & acknowledgements
 


### PR DESCRIPTION
Hey all,

   Just following on https://github.com/privacycg/is-logged-in/issues/53.

   I took the time to write down how, concretely, we think FedCM could reconcile with the Login Status API in this PR. You can see a preview of the text [here](https://github.com/samuelgoto/login-status-api).

   @bvandersloot-mozilla, does this make more or less sense to you?

   I didn't include a spec, since I wanted to try to gather some convergence at a high level before writing spec language.

   I worked with @johannhof who is also interested in exploring how/whether this would help the Storage Access API, and he wrote a section on how that may play out to give you all a sense of how we think this may evolve.

   @johnwilander WDYT?
